### PR TITLE
nppColdFusion 0.6.2 + SQLite

### DIFF
--- a/files.sql
+++ b/files.sql
@@ -314,4 +314,6 @@ insert into FileHash(md5sum, filename, pluginName, addedDate, status) values ('a
 insert into FileHash(md5sum, filename, pluginName, addedDate, status) values ('0d9e0f7909a8e31c21a390ee7b25f017','nppColdFusion.dll','','2011-04-03','ok');
 insert into FileHash(md5sum, filename, pluginName, addedDate, status) values ('EE006A4B4E1BEE7F962E59D773CF82AC','nppColdFusion.dll','','2011-04-05','ok');
 insert into FileHash(md5sum, filename, pluginName, addedDate, status) values ('B2232D645FAD62FD49D7D3EFCB7B5FB4','sqlite3.dll','','2011-04-05','ok');
+insert into FileHash(md5sum, filename, pluginName, addedDate, status) values ('65664479747F0A9048C7921F63D6AAAD','nppColdFusion.dll','','2011-07-10','ok');
+
 commit;

--- a/files.sql
+++ b/files.sql
@@ -312,4 +312,6 @@ insert into FileHash(md5sum, filename, pluginName, addedDate, status) values ('3
 insert into FileHash(md5sum, filename, pluginName, addedDate, status) values ('40d484fa1ed493d68127fe95dc624410','JSLintNppA.dll','','2011-04-03','ok');
 insert into FileHash(md5sum, filename, pluginName, addedDate, status) values ('a86ed444a2bb156f763be87b33a115c4','PythonScript.dll','','2011-04-03','ok');
 insert into FileHash(md5sum, filename, pluginName, addedDate, status) values ('0d9e0f7909a8e31c21a390ee7b25f017','nppColdFusion.dll','','2011-04-03','ok');
+insert into FileHash(md5sum, filename, pluginName, addedDate, status) values ('EE006A4B4E1BEE7F962E59D773CF82AC','nppColdFusion.dll','','2011-04-05','ok');
+insert into FileHash(md5sum, filename, pluginName, addedDate, status) values ('B2232D645FAD62FD49D7D3EFCB7B5FB4','sqlite3.dll','','2011-04-05','ok');
 commit;

--- a/plugins.xml
+++ b/plugins.xml
@@ -133,17 +133,21 @@
 		</install>
 	</plugin>
 	<plugin name="ColdFusion Lexer">
-		<unicodeVersion>0.6.0</unicodeVersion>
+		<unicodeVersion>0.6.2</unicodeVersion>
 		<author>bbluemel</author>
 		<description>Syntax highlighting, Call tips (Notepad++ 5.8.4 required) and autocomplete for the ColdFusion language</description>
+		<dependencies>
+			<plugin name="SQLite"/>
+		</dependencies>
 		<versions>
+			<version number="0.6.2" md5="EE006A4B4E1BEE7F962E59D773CF82AC" />
 			<version number="0.6.0" md5="0D9E0F7909A8E31C21A390EE7B25F017" />
 			<version number="0.5.3" md5="63e009627d1c07c2064db276c3a22bd3" />
 		</versions>
 		<install>
-			<download>http://www.nppcf.com/files/nppColdFusion-0.6.0beta.zip</download>
+			<download>http://www.nppcf.com/files/nppColdFusion-0.6.2beta.zip</download>
 			<copy from="nppColdFusion.dll" to="$PLUGINDIR$" validate="true"/>
-			<copy from="nppColdFusion.db3" to="$CONFIGDIR$" />
+			<copy from="Config\nppColdFusion.db3" to="$CONFIGDIR$" />
 			<copy from="Config\nppColdFusion.xml" to="$CONFIGDIR$" />
 		</install>
 	</plugin>
@@ -1467,6 +1471,20 @@
 			<copy from="SpellChecker.dll" to="$PLUGINDIR$" validate="true"/>
 		</install>
 	</plugin>
+	
+	<plugin name="SQLite">
+		<unicodeVersion>3.7.5</unicodeVersion>
+		<author>sqlite.org</author>
+		<description>SQLite 3.7.5</description>
+		<versions>
+			<version number="3.7.5" md5="B2232D645FAD62FD49D7D3EFCB7B5FB4" />
+		</versions>
+		<install>
+			<download>http://www.sqlite.org/sqlite-dll-win32-x86-3070500.zip</download>
+			<copy from="sqlite3.dll" to="$NPPDIR$" validate="true"/>
+		</install>
+	</plugin>
+	
 	<plugin name="Squiggly Spell">
 		<!-- Disabled until errors repaired <unicodeVersion>0.0.1</unicodeVersion> --> <description>Spellchecker tbat underlines misspelled words as you type.  Requires Aspell to be installed (http://aspell.net/win32).</description>
 		<sourceUrl>http://sourceforge.net/projects/squiggly/develop</sourceUrl>

--- a/plugins.xml
+++ b/plugins.xml
@@ -133,19 +133,20 @@
 		</install>
 	</plugin>
 	<plugin name="ColdFusion Lexer">
-		<unicodeVersion>0.6.2</unicodeVersion>
+		<unicodeVersion>0.7</unicodeVersion>
 		<author>bbluemel</author>
 		<description>Syntax highlighting, Call tips (Notepad++ 5.8.4 required) and autocomplete for the ColdFusion language</description>
 		<dependencies>
 			<plugin name="SQLite"/>
 		</dependencies>
 		<versions>
+			<version number="0.7" md5="65664479747F0A9048C7921F63D6AAAD" />
 			<version number="0.6.2" md5="EE006A4B4E1BEE7F962E59D773CF82AC" />
 			<version number="0.6.0" md5="0D9E0F7909A8E31C21A390EE7B25F017" />
 			<version number="0.5.3" md5="63e009627d1c07c2064db276c3a22bd3" />
 		</versions>
 		<install>
-			<download>http://www.nppcf.com/files/nppColdFusion-0.6.2beta.zip</download>
+			<download>http://www.nppcf.com/files/nppColdFusion-0.7.zip</download>
 			<copy from="nppColdFusion.dll" to="$PLUGINDIR$" validate="true"/>
 			<copy from="Config\nppColdFusion.db3" to="$CONFIGDIR$" />
 			<copy from="Config\nppColdFusion.xml" to="$CONFIGDIR$" />
@@ -1473,14 +1474,13 @@
 	</plugin>
 	
 	<plugin name="SQLite">
-		<unicodeVersion>3.7.5</unicodeVersion>
 		<author>sqlite.org</author>
-		<description>SQLite 3.7.5</description>
+		<description>SQLite 3.7.7.1</description>
 		<versions>
-			<version number="3.7.5" md5="B2232D645FAD62FD49D7D3EFCB7B5FB4" />
+			<version number="3.7.7.1" />
 		</versions>
 		<install>
-			<download>http://www.sqlite.org/sqlite-dll-win32-x86-3070500.zip</download>
+			<download>http://sqlite.org/sqlite-dll-win32-x86-3070701.zip</download>
 			<copy from="sqlite3.dll" to="$NPPDIR$" validate="true"/>
 		</install>
 	</plugin>


### PR DESCRIPTION
Hi Dave,

Fixed a crashing bug with my plugin, and have separated out sqlite3.dll, I managed to get the test plugin manager running, however, with this it said it couldn't validate either sqlite3.dll or nppColdFusion.dll.. I used HashTab to generate the hashes (which I also did for 0.6.0, so not sure why).

Hopefully set up the SQLite "plugin" fine too.

Cheers

Ben
