### PR TITLE
AutoSave 1.3 : Incorrect Download Location

### DIFF
--- a/plugins.xml
+++ b/plugins.xml
@@ -39,7 +39,7 @@
 		<sourceUrl/>
 		<latestUpdate>adds a requested functionality to ignore files larger than a specified size.</latestUpdate>
 		<install>
-			<download>http://sites.google.com/site/fstellari/cab/AutoSave_dll_1v30.zip?attredirects=0</download>
+			<download>http://sites.google.com/site/fstellari/nppplugins/AutoSave_dll_1v30.zip?attredirects=0</download>
 			<ansi>
 				<copy from="AutoSaveA.dll" to="$PLUGINDIR$" validate="true"/>
 			</ansi>


### PR DESCRIPTION
Hi DaveQB3,
I don't know when the change occurred (my first attempt to install the Plugin with the Plugin Manager was earlier today), but the “AutoSave” version 1.3 Download Location is slightly different from what the Plugin Manager is currently attempting to use ("nppplugins" now instead of "cab" folder).
